### PR TITLE
🐛 : heightの指定でアスペクト比率が崩れているため修正

### DIFF
--- a/src/components/features/home/ServiceIntroduction.js
+++ b/src/components/features/home/ServiceIntroduction.js
@@ -41,8 +41,8 @@ const ServiceIntroductionPages = () => {
                 src={serviceHeadNumber1}
                 alt='1'
                 width={37}
-                height={91}
                 className='mr-6'
+                priority
                 style={{
                   objectFit: 'cover',
                 }}
@@ -74,8 +74,8 @@ const ServiceIntroductionPages = () => {
                 src={serviceHeadNumber2}
                 alt='2'
                 width={53}
-                height={91}
                 className='mr-6'
+                priority
                 style={{
                   objectFit: 'cover',
                 }}
@@ -107,8 +107,8 @@ const ServiceIntroductionPages = () => {
                 src={serviceHeadNumber3}
                 alt='1'
                 width={56}
-                height={91}
                 className='mr-6'
+                priority
                 style={{
                   objectFit: 'cover',
                 }}


### PR DESCRIPTION
## やったこと

- 画像のようなwarnの解消
  <img width="602" alt="image" src="https://github.com/user-attachments/assets/3099d906-bc93-4aa1-824c-b174745e7752">

- LCPの警告に対する対応

## 実装内容

画像のwidthの指定に対してheightの指定がアスペクト比率を崩していたため、widthのみの指定でheightはコンポーネントに委ねる形に変更

## Issue

close #48 