### PR TITLE
🩹 : 初期値の型をスキーマにあわせる

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -11,7 +11,7 @@ inputs:
   husky:
     description: 'Whether to disable Husky hooks during CI/CD'
     required: false
-    default: 0
+    default: '0'
 
 runs:
   using: 'composite'


### PR DESCRIPTION
## 概要

defaultの値の型を`number`から`string`に変更