### PR TITLE
ローディング完了後にコンテンツを表示するよう初期アニメーションを修正

### DIFF
--- a/src/components/features/home/Hero.js
+++ b/src/components/features/home/Hero.js
@@ -1,32 +1,72 @@
+'use client'
+
+import { motion } from 'framer-motion'
 import Image from 'next/image'
+import { useLoading } from '@/hooks/useLoading'
 import kikaraLogo from '@/public/images/kikara-logo.png'
 import mainHeroImage from '@/public/images/mainHeroImage.png'
 
 const HeroSection = () => {
+  const { isReady } = useLoading()
+
+  const containerVariants = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        when: 'beforeChildren',
+        staggerChildren: 0.15,
+        delayChildren: 0.2,
+      },
+    },
+  }
+
+  const imageVariants = {
+    hidden: { opacity: 0, scale: 1.05 },
+    visible: { opacity: 1, scale: 1, transition: { duration: 1.2, ease: 'easeOut' } },
+  }
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 24 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.8, ease: 'easeOut' } },
+  }
+
   return (
-    <div id='hero' className='relative flex min-h-screen'>
+    <motion.div
+      id='hero'
+      className='relative flex min-h-screen'
+      initial='hidden'
+      animate={isReady ? 'visible' : 'hidden'}
+      variants={containerVariants}
+    >
       {/* Background image (full-screen on SP, right panel on md+) */}
-      <div className='absolute inset-0 md:relative md:inset-auto md:w-[60%] md:flex-shrink-0'>
+      <motion.div
+        className='absolute inset-0 md:relative md:inset-auto md:w-[60%] md:flex-shrink-0'
+        variants={imageVariants}
+      >
         <Image src={mainHeroImage} alt='Kikara' fill priority className='object-cover' />
         <div className='absolute inset-0 bg-black/40 md:hidden' />
-      </div>
+      </motion.div>
 
       {/* Text overlay: centered on SP, left panel on md+ */}
       <div className='relative z-10 flex w-full flex-col items-center justify-center px-8 text-center md:order-first md:w-[40%] md:items-start md:px-14 md:text-left lg:px-20'>
-        <p className='text-xs tracking-[.3em] text-white drop-shadow md:text-gray-400 md:drop-shadow-none'>
+        <motion.p
+          className='text-xs tracking-[.3em] text-white drop-shadow md:text-gray-400 md:drop-shadow-none'
+          variants={itemVariants}
+        >
           ミネラル醗酵ドリンク
-        </p>
-        <h1 className='mt-3 leading-none drop-shadow md:drop-shadow-none'>
+        </motion.p>
+        <motion.h1 className='mt-3 leading-none drop-shadow md:drop-shadow-none' variants={itemVariants}>
           <Image
             src={kikaraLogo}
             alt='Kikara'
             height={72}
             className='h-14 w-auto object-contain brightness-0 drop-shadow invert md:h-20 md:brightness-100 md:drop-shadow-none md:invert-0'
           />
-        </h1>
-        <div className='mt-6 h-px w-8 bg-white md:bg-gray-300' />
+        </motion.h1>
+        <motion.div className='mt-6 h-px w-8 bg-white md:bg-gray-300' variants={itemVariants} />
       </div>
-    </div>
+    </motion.div>
   )
 }
 

--- a/src/components/layouts/Body.js
+++ b/src/components/layouts/Body.js
@@ -4,6 +4,7 @@ import { AnimatePresence } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState, useMemo } from 'react'
 import '@/app/globals.css'
+import { LoadingProvider } from '@/hooks/useLoading'
 import Footer from './Footer'
 import Header from './Header'
 import PageAnimation from './PageAnimation'
@@ -36,14 +37,16 @@ const Body = ({ children }) => {
 
   return (
     <body className='relative font-sans'>
-      <AnimatePresence mode='wait'>
-        <div key={pathname} className='overflow-x-hidden'>
-          {isActiveAnimate && <PageAnimation />}
-          <Header />
-          <main className='min-h-[calc(100vh-465px)] bg-kikara-white'>{children}</main>
-          <Footer />
-        </div>
-      </AnimatePresence>
+      <LoadingProvider>
+        <AnimatePresence mode='wait'>
+          <div key={pathname} className='overflow-x-hidden'>
+            {isActiveAnimate && <PageAnimation />}
+            <Header />
+            <main className='min-h-[calc(100vh-465px)] bg-kikara-white'>{children}</main>
+            <Footer />
+          </div>
+        </AnimatePresence>
+      </LoadingProvider>
     </body>
   )
 }

--- a/src/components/layouts/PageAnimation.js
+++ b/src/components/layouts/PageAnimation.js
@@ -1,15 +1,12 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { usePathname } from 'next/navigation'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 // UXベストプラクティスのいわゆる「3秒ルール」に基づく最低表示時間
 const MIN_DISPLAY_MS = 3000
 
 const PageAnimation = () => {
-  const pathname = usePathname()
-  const isTopPage = useMemo(() => pathname === '/', [pathname])
   const [isReady, setIsReady] = useState(false)
 
   useEffect(() => {
@@ -49,20 +46,7 @@ const PageAnimation = () => {
       transition={{ duration: 0.6, ease: 'easeInOut' }}
       className='fixed inset-0 left-0 top-0 z-50 flex h-lvh items-center justify-center bg-secondary-brown'
     >
-      <div className='flex flex-col items-center justify-center gap-6 text-kikara-white'>
-        {isTopPage && (
-          <div className='flex flex-col items-center justify-center'>
-            <p className='text-xs md:text-md'>くらし・ととのう・さろん</p>
-            <p className='text-4xl tracking-wide md:text-[4rem]'>Kikara</p>
-          </div>
-        )}
-        <div className='flex items-center gap-2'>
-          <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-kikara-white [animation-delay:-0.3s]' />
-          <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-kikara-white [animation-delay:-0.15s]' />
-          <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-kikara-white' />
-          <p className='ml-2 text-sm tracking-[0.3em]'>Loading...</p>
-        </div>
-      </div>
+      <p className='text-sm tracking-[0.3em] text-kikara-white'>Loading...</p>
     </motion.div>
   )
 }

--- a/src/components/layouts/PageAnimation.js
+++ b/src/components/layouts/PageAnimation.js
@@ -4,6 +4,9 @@ import { motion } from 'framer-motion'
 import { usePathname } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 
+// UXベストプラクティスのいわゆる「3秒ルール」に基づく最低表示時間
+const MIN_DISPLAY_MS = 3000
+
 const PageAnimation = () => {
   const pathname = usePathname()
   const isTopPage = useMemo(() => pathname === '/', [pathname])
@@ -12,7 +15,7 @@ const PageAnimation = () => {
   useEffect(() => {
     let cancelled = false
 
-    const waitForReady = async () => {
+    const waitForResources = async () => {
       try {
         if (document.fonts?.ready) {
           await document.fonts.ready
@@ -26,11 +29,14 @@ const PageAnimation = () => {
           window.addEventListener('load', resolve, { once: true })
         })
       }
-
-      if (!cancelled) setIsReady(true)
     }
 
-    waitForReady()
+    const minimumDisplay = new Promise((resolve) => setTimeout(resolve, MIN_DISPLAY_MS))
+
+    Promise.all([waitForResources(), minimumDisplay]).then(() => {
+      if (!cancelled) setIsReady(true)
+    })
+
     return () => {
       cancelled = true
     }

--- a/src/components/layouts/PageAnimation.js
+++ b/src/components/layouts/PageAnimation.js
@@ -46,7 +46,25 @@ const PageAnimation = () => {
       transition={{ duration: 0.6, ease: 'easeInOut' }}
       className='fixed inset-0 left-0 top-0 z-50 flex h-lvh items-center justify-center bg-secondary-brown'
     >
-      <p className='text-sm tracking-[0.3em] text-kikara-white'>Loading...</p>
+      <p className='flex items-baseline text-sm tracking-[0.3em] text-kikara-white'>
+        <span>Loading</span>
+        {[0, 1, 2].map((i) => (
+          <motion.span
+            key={i}
+            className='ml-0.5 inline-block'
+            animate={{ opacity: [0, 1, 1, 0] }}
+            transition={{
+              duration: 1.5,
+              times: [0, 0.3, 0.7, 1],
+              repeat: Infinity,
+              delay: i * 0.2,
+              ease: 'easeInOut',
+            }}
+          >
+            .
+          </motion.span>
+        ))}
+      </p>
     </motion.div>
   )
 }

--- a/src/components/layouts/PageAnimation.js
+++ b/src/components/layouts/PageAnimation.js
@@ -1,43 +1,10 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { useEffect, useState } from 'react'
-
-// UXベストプラクティスのいわゆる「3秒ルール」に基づく最低表示時間
-const MIN_DISPLAY_MS = 3000
+import { useLoading } from '@/hooks/useLoading'
 
 const PageAnimation = () => {
-  const [isReady, setIsReady] = useState(false)
-
-  useEffect(() => {
-    let cancelled = false
-
-    const waitForResources = async () => {
-      try {
-        if (document.fonts?.ready) {
-          await document.fonts.ready
-        }
-      } catch {
-        // ignore font readiness errors
-      }
-
-      if (document.readyState !== 'complete') {
-        await new Promise((resolve) => {
-          window.addEventListener('load', resolve, { once: true })
-        })
-      }
-    }
-
-    const minimumDisplay = new Promise((resolve) => setTimeout(resolve, MIN_DISPLAY_MS))
-
-    Promise.all([waitForResources(), minimumDisplay]).then(() => {
-      if (!cancelled) setIsReady(true)
-    })
-
-    return () => {
-      cancelled = true
-    }
-  }, [])
+  const { isReady } = useLoading()
 
   return (
     <motion.div

--- a/src/components/layouts/PageAnimation.js
+++ b/src/components/layouts/PageAnimation.js
@@ -1,45 +1,63 @@
+'use client'
+
 import { motion } from 'framer-motion'
-import Lottie from 'lottie-react'
 import { usePathname } from 'next/navigation'
-import { useMemo } from 'react'
-import animationData from '@/public/animation.json'
+import { useEffect, useMemo, useState } from 'react'
 
 const PageAnimation = () => {
   const pathname = usePathname()
   const isTopPage = useMemo(() => pathname === '/', [pathname])
-  return (
-    <div>
-      {/* 全ページ共通アニメーション */}
-      <motion.div
-        animate={{
-          opacity: [1, 0.75, 0],
-          transitionEnd: { display: 'none' },
-        }}
-        transition={{ duration: 2.2 }}
-        className='fixed inset-0 left-0 top-0 z-50 h-lvh bg-secondary-brown [&>div]:-ml-[50vw] [&>div]:-mt-[30vh] [&>div]:h-[160vh] [&>div]:w-[200vw] xl:[&>div]:-mt-[10vh] xl:[&>div]:ml-0 xl:[&>div]:w-auto [&_svg]:object-cover'
-      >
-        <Lottie animationData={animationData} loop={false} rendererSettings={{ preserveAspectRatio: 'none' }} />
-      </motion.div>
+  const [isReady, setIsReady] = useState(false)
 
-      {/* トップページ専用アニメーション */}
-      {isTopPage && (
-        <motion.div
-          className='fixed left-0 top-0 z-40 h-lvh w-full bg-kikara-white'
-          animate={{ opacity: [1, 0.95, 0], transitionEnd: { display: 'none' } }}
-          transition={{ duration: 2.8, times: [0, 0.95, 1] }}
-        >
-          <motion.div
-            className='absolute left-1/2 top-[50svh] flex -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center'
-            initial={{ opacity: 0 }}
-            animate={{ opacity: [0, 0.95, 0] }}
-            transition={{ duration: 2.8, times: [0, 0.95, 1] }}
-          >
+  useEffect(() => {
+    let cancelled = false
+
+    const waitForReady = async () => {
+      try {
+        if (document.fonts?.ready) {
+          await document.fonts.ready
+        }
+      } catch {
+        // ignore font readiness errors
+      }
+
+      if (document.readyState !== 'complete') {
+        await new Promise((resolve) => {
+          window.addEventListener('load', resolve, { once: true })
+        })
+      }
+
+      if (!cancelled) setIsReady(true)
+    }
+
+    waitForReady()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <motion.div
+      initial={{ opacity: 1 }}
+      animate={isReady ? { opacity: 0, transitionEnd: { display: 'none' } } : { opacity: 1 }}
+      transition={{ duration: 0.6, ease: 'easeInOut' }}
+      className='fixed inset-0 left-0 top-0 z-50 flex h-lvh items-center justify-center bg-secondary-brown'
+    >
+      <div className='flex flex-col items-center justify-center gap-6 text-kikara-white'>
+        {isTopPage && (
+          <div className='flex flex-col items-center justify-center'>
             <p className='text-xs md:text-md'>くらし・ととのう・さろん</p>
             <p className='text-4xl tracking-wide md:text-[4rem]'>Kikara</p>
-          </motion.div>
-        </motion.div>
-      )}
-    </div>
+          </div>
+        )}
+        <div className='flex items-center gap-2'>
+          <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-kikara-white [animation-delay:-0.3s]' />
+          <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-kikara-white [animation-delay:-0.15s]' />
+          <span className='inline-block h-2 w-2 animate-pulse rounded-full bg-kikara-white' />
+          <p className='ml-2 text-sm tracking-[0.3em]'>Loading...</p>
+        </div>
+      </div>
+    </motion.div>
   )
 }
 

--- a/src/hooks/useLoading.jsx
+++ b/src/hooks/useLoading.jsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+// UXの「3秒ルール」に基づく最低表示時間
+const MIN_DISPLAY_MS = 3000
+
+const LoadingContext = createContext({ isReady: false })
+
+export const LoadingProvider = ({ children }) => {
+  const [isReady, setIsReady] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const waitForResources = async () => {
+      try {
+        if (document.fonts?.ready) {
+          await document.fonts.ready
+        }
+      } catch {
+        // ignore font readiness errors
+      }
+
+      if (document.readyState !== 'complete') {
+        await new Promise((resolve) => {
+          window.addEventListener('load', resolve, { once: true })
+        })
+      }
+    }
+
+    const minimumDisplay = new Promise((resolve) => setTimeout(resolve, MIN_DISPLAY_MS))
+
+    Promise.all([waitForResources(), minimumDisplay]).then(() => {
+      if (!cancelled) setIsReady(true)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return <LoadingContext.Provider value={{ isReady }}>{children}</LoadingContext.Provider>
+}
+
+export const useLoading = () => useContext(LoadingContext)


### PR DESCRIPTION
固定時間のLottieアニメーションをやめ、「Loading...」表示に変更。
フォントと全リソース（window load）の読み込み完了を待ってから
フェードアウトしてコンテンツを表示するようにした。

https://claude.ai/code/session_011pFAR9wUGtxVdVcmgS8gTq